### PR TITLE
새로운 2015/list API에 맞게 데이터를 리스트에 뿌려줌

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,11 +14,6 @@
             android:name=".ui.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/DeviewAppTheme_MaterialViewPager" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".ui.setting.SettingActivity"
@@ -27,7 +22,11 @@
         <activity
             android:name=".ui.splashlogin.SplashLoginActivity"
             android:label="@string/app_name" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
         <activity
             android:name="com.facebook.FacebookActivity"

--- a/app/src/main/java/com/gdgssu/android_deviewsched/model/Session.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/model/Session.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 public class Session implements Serializable {
 
     public int id;
-    public String session_title;
+    public String title;
     public ArrayList<Speaker> speakers;
 
 }

--- a/app/src/main/java/com/gdgssu/android_deviewsched/model/Speaker.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/model/Speaker.java
@@ -8,6 +8,6 @@ import java.io.Serializable;
 public class Speaker implements Serializable {
 
     public String name;
-    public String img;
+    public String picture;
 
 }

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/detailsession/DetailSessionActivity.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/detailsession/DetailSessionActivity.java
@@ -96,9 +96,6 @@ public class DetailSessionActivity extends AppCompatActivity {
             }
         });
 
-        TextView sessionTarget = (TextView)headerView.findViewById(R.id.item_detail_session_header_sessiontarget);
-        sessionTarget.setText("훌륭한 프로그래머가 되고싶은 모든 프로그래머");
-
         TextView sessionContent = (TextView)headerView.findViewById(R.id.item_detail_session_header_sessioninfo);
         sessionContent.setText(dummyText);
 

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/sche/SchePagerAdapter.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/sche/SchePagerAdapter.java
@@ -93,7 +93,7 @@ public class SchePagerAdapter extends BaseAdapter {
             setOneSpeakerInfo(sessionHolder, sessionItem);
         }
 
-        sessionHolder.sessionName.setText(sessionItem.session_title);
+        sessionHolder.sessionName.setText(sessionItem.title);
 
         return convertView;
     }
@@ -102,7 +102,7 @@ public class SchePagerAdapter extends BaseAdapter {
         sessionHolder.speakerImgSecond.setVisibility(View.GONE);
 
         Glide.with(DeviewSchedApplication.GLOBAL_CONTEXT)
-                .load(sessionItem.speakers.get(0).img)
+                .load(sessionItem.speakers.get(0).picture)
                 .transform(new GlideCircleTransform(DeviewSchedApplication.GLOBAL_CONTEXT))
                 .override(54, 54) //임의로 결정한 크기임.
                 .into(sessionHolder.speakerImg);
@@ -114,13 +114,13 @@ public class SchePagerAdapter extends BaseAdapter {
         sessionHolder.speakerImgSecond.setVisibility(View.VISIBLE);
 
         Glide.with(DeviewSchedApplication.GLOBAL_CONTEXT)
-                .load(sessionItem.speakers.get(0).img)
+                .load(sessionItem.speakers.get(0).picture)
                 .transform(new GlideCircleTransform(DeviewSchedApplication.GLOBAL_CONTEXT))
                 .override(54, 54) //임의로 결정한 크기임.
                 .into(sessionHolder.speakerImg);
 
         Glide.with(DeviewSchedApplication.GLOBAL_CONTEXT)
-                .load(sessionItem.speakers.get(1).img)
+                .load(sessionItem.speakers.get(1).picture)
                 .transform(new GlideCircleTransform(DeviewSchedApplication.GLOBAL_CONTEXT))
                 .override(54, 54) //임의로 결정한 크기임.
                 .into(sessionHolder.speakerImgSecond);

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/sche/SchePagerFragment.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/sche/SchePagerFragment.java
@@ -15,10 +15,16 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
 import com.gdgssu.android_deviewsched.DeviewSchedApplication;
 import com.gdgssu.android_deviewsched.R;
+import com.gdgssu.android_deviewsched.model.AllScheItems;
+import com.gdgssu.android_deviewsched.model.Session;
 import com.gdgssu.android_deviewsched.model.Track;
 import com.gdgssu.android_deviewsched.ui.detailsession.DetailSessionActivity;
+
+import static com.navercorp.volleyextensions.volleyer.Volleyer.volleyer;
 
 public class SchePagerFragment extends Fragment {
 
@@ -64,14 +70,14 @@ public class SchePagerFragment extends Fragment {
 
     private void initScheListView(View rootView) {
         final ListView listview = (ListView) rootView.findViewById(R.id.fragment_sche_pager_list);
-        SchePagerAdapter adapter = new SchePagerAdapter(mTrackData, DeviewSchedApplication.GLOBAL_CONTEXT);
+        final SchePagerAdapter adapter = new SchePagerAdapter(mTrackData, DeviewSchedApplication.GLOBAL_CONTEXT);
 
         //임시로 아이템을 누르면 테스트중인 액티비티가 뜨게 만들어놓음
         listview.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 if (sessionPickMode) {
-                    listview.getChildAt(position).setBackgroundColor(getActivity().getColor(android.R.color.holo_blue_light));
+                    //  listview.getChildAt(position).setBackgroundColor(getActivity().getColor(android.R.color.holo_blue_light));
                 } else {
                     getActivity().startActivity(new Intent(getActivity(), DetailSessionActivity.class));
                 }

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/splashlogin/SplashLoginActivity.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/splashlogin/SplashLoginActivity.java
@@ -102,7 +102,7 @@ public class SplashLoginActivity extends AppCompatActivity implements FacebookCa
     private void getAllScheData() {
 
         volleyer(DeviewSchedApplication.deviewRequestQueue)
-                .get(DeviewSchedApplication.HOST_URL + "mock/allsche.json")
+                .get(DeviewSchedApplication.HOST_URL + "2015/list")
                 .withTargetClass(AllScheItems.class)
                 .withListener(new Response.Listener<AllScheItems>() {
                     @Override

--- a/app/src/main/res/layout/item_detail_session_header.xml
+++ b/app/src/main/res/layout/item_detail_session_header.xml
@@ -83,23 +83,6 @@
                     android:text=""
                     android:textSize="12sp" />
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="left"
-                    android:text="강의대상"
-                    android:textSize="12sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/item_detail_session_header_sessiontarget"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginBottom="12dp"
-                    android:text="개발을 잘하고 싶은 초보 개발자"
-                    android:textSize="12sp" />
-
             </LinearLayout>
         </RelativeLayout>
 


### PR DESCRIPTION
새로운 2015/list API에 맞게 데이터를 리스트에 뿌려줌
- 모델 클래스에서 API에 맞는 이름으로 변수이름 수정
- 강의대상 관련 텍스트뷰 삭제

해결해야 할 이슈 : 
- 세션 리스트가 데뷰 시간표와 같은 순서대로 나오지 않는점
- Day1과 Day2로 나누어서 데이터를 뿌려줘야할것같음..

![2015-08-24 15 50 51](https://cloud.githubusercontent.com/assets/13411760/9434181/e175aa2e-4a76-11e5-97d1-8857576be262.png)
