### PR TITLE
Travis: Add initial travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: android
+android:
+ components:
+  - tools
+  - build-tools-23.0.2
+  - android-23
+  - extra-android-m2repository
+
+  - sys-img-armeabi-v7a-android-21
+
+script:
+  # By default Travis-ci executes './gradlew build connectedCheck' if no 'script:' section found.
+  - ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Deviewsched-android
+[![Build Status](https://travis-ci.org/GDG-SSU/deviewsched-android.svg?branch=master)](https://travis-ci.org/GDG-SSU/deviewsched-android)
+
 Deviewsched project for Deview 2016
 
 ## 프로젝트 소개

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,10 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 repositories {


### PR DESCRIPTION
안드로이드 어플리케이션을 빌드하는 travis 스크립트 입니다.
빌드 시간 때문에 테스트 기능은 뺐습니다.

lint 오류가 발생할시 바로 빌드 실패로 떠서, lint 오류는 무시합니다.

EDIT
Readme.md에 빌드 상황을 표시하는 이미지를 추가했습니다.
