### PR TITLE
Kahyae/license

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile('de.psdev.licensesdialog:licensesdialog:1.8.0')
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:cardview-v7:23.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile('de.psdev.licensesdialog:licensesdialog:1.8.0')
+    compile 'de.psdev.licensesdialog:licensesdialog:1.8.0'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:cardview-v7:23.1.1'

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/setting/PreferenceFragment.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/setting/PreferenceFragment.java
@@ -6,9 +6,12 @@ import android.os.Bundle;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
+import android.view.View;
 
 import com.gdgssu.android_deviewsched.R;
 import com.gdgssu.android_deviewsched.util.LogUtils;
+
+import de.psdev.licensesdialog.LicensesDialogFragment;
 
 import static com.gdgssu.android_deviewsched.util.LogUtils.makeLogTag;
 
@@ -54,14 +57,26 @@ public class PreferenceFragment extends PreferenceFragmentCompat implements Shar
 
             case KEY_PREF_OSSLICENSES:
                 //Todo : SettingActivity에서 PreferenceFragment에서 OSSlicensesFragment로 전환하는 로직 작성
-                mListener.onFragmentChange();
-
+               // mListener.onFragmentChange();
+                try {
+                    onMultipleIncludeOwnFragmentClick(getView());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
                 break;
         }
 
         return super.onPreferenceTreeClick(preference);
     }
+    public void onMultipleIncludeOwnFragmentClick(final View view) throws Exception {
+        final LicensesDialogFragment fragment = new LicensesDialogFragment.Builder(getActivity())
+                .setNotices(R.raw.notices)
+                .setShowFullLicenseText(false)
+                .setIncludeOwnLicense(true)
+                .build();
 
+        fragment.show(getFragmentManager(), null);
+    }
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/setting/PreferenceFragment.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/setting/PreferenceFragment.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.view.View;
 
 import com.gdgssu.android_deviewsched.R;
 import com.gdgssu.android_deviewsched.util.LogUtils;
@@ -57,9 +56,8 @@ public class PreferenceFragment extends PreferenceFragmentCompat implements Shar
 
             case KEY_PREF_OSSLICENSES:
                 //Todo : SettingActivity에서 PreferenceFragment에서 OSSlicensesFragment로 전환하는 로직 작성
-               // mListener.onFragmentChange();
                 try {
-                    onMultipleIncludeOwnFragmentClick(getView());
+                    onMultipleIncludeOwnFragmentClick();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -68,14 +66,14 @@ public class PreferenceFragment extends PreferenceFragmentCompat implements Shar
 
         return super.onPreferenceTreeClick(preference);
     }
-    public void onMultipleIncludeOwnFragmentClick(final View view) throws Exception {
+    public void onMultipleIncludeOwnFragmentClick() throws Exception {
         final LicensesDialogFragment fragment = new LicensesDialogFragment.Builder(getActivity())
                 .setNotices(R.raw.notices)
                 .setShowFullLicenseText(false)
                 .setIncludeOwnLicense(true)
                 .build();
 
-        fragment.show(getFragmentManager(), null);
+        fragment.show(getFragmentManager(), "LicensesDialogFragment");
     }
     @Override
     public void onAttach(Context context) {

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2013 Philip Schiffer
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+<notices>
+    <notice>
+        <name>ActionBarSherlock</name>
+        <url>http://actionbarsherlock.com/</url>
+        <copyright>Copyright 2012 Jake Wharton</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>RoboGuice 2.0</name>
+        <url>http://roboguice.org</url>
+        <copyright/>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Application Crash Reporting for Android (ACRA)</name>
+        <url>http://acra.ch/</url>
+        <copyright>Copyright 2010 Emmanuel Astier &amp; Kevin Gaudin</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Android ViewPagerIndicator</name>
+        <url>http://viewpagerindicator.com/</url>
+        <copyright>Copyright (C) 2011 The Android Open Source Project&lt;br/&gt;Copyright (C) 2012 Jake Wharton</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Nine Old Androids</name>
+        <url>http://nineoldandroids.com/</url>
+        <copyright>Copyright (C) 2010 The Android Open Source Project</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Crouton</name>
+        <url>https://github.com/keyboardsurfer/Crouton</url>
+        <copyright>Copyright 2012 Benjamin Weiss&lt;br/&gt;Copyright 2012 Neofonie Mobile GmbH</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Jackson JSON-processor</name>
+        <url>http://jackson.codehaus.org/</url>
+        <copyright/>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>OrmLite</name>
+        <url>http://ormlite.com/</url>
+        <copyright>Copyright Gray Watson</copyright>
+        <license>ISC License</license>
+    </notice>
+    <notice>
+        <name>Apache Commons IO</name>
+        <url>http://commons.apache.org/io/</url>
+        <copyright>Copyright 2002-2012 The Apache Software Foundation</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Apache Commons Lang</name>
+        <url>http://commons.apache.org/lang/</url>
+        <copyright>Copyright 2002-2011 The Apache Software Foundation</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Joda Time</name>
+        <url>http://joda-time.sourceforge.net/</url>
+        <copyright>Copyright 2001-2005 Stephen Colebourne</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>StickyListHeaders</name>
+        <url>https://github.com/emilsjolander/StickyListHeaders</url>
+        <copyright>Copyright 2012 Emil Sjölander</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>DiskLruCache</name>
+        <url>https://github.com/JakeWharton/DiskLruCache</url>
+        <copyright>Copyright (C) 2011 The Android Open Source Project&lt;br/&gt;Copyright 2012 Jake Wharton</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Google Guava</name>
+        <url>http://code.google.com/p/guava-libraries/</url>
+        <copyright>Copyright (C) 2007 The Guava Authors</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>PhotoView</name>
+        <url>https://github.com/chrisbanes/PhotoView</url>
+        <copyright>Copyright 2011, 2012 Chris Banes.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Inscription</name>
+        <url>https://github.com/MartinvanZ/Inscription</url>
+        <copyright>(c) 2012 Martin van Zuilekom (http://martin.cubeactive.com)</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Cool Project with BSD License</name>
+        <url>http://example.com</url>
+        <copyright>Author of Cool Project with BSD License</copyright>
+        <license>BSD 3-Clause License</license>
+    </notice>
+</notices>

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -17,105 +17,62 @@
   -->
 <notices>
     <notice>
-        <name>ActionBarSherlock</name>
-        <url>http://actionbarsherlock.com/</url>
-        <copyright>Copyright 2012 Jake Wharton</copyright>
+        <name>robolectric</name>
+        <url>http://robolectric.org/</url>
+        <copyright>Copyright (c) 2010 Xtreme Labs and Pivotal Labs</copyright>
+        <license>MIT License</license>
+    </notice>
+    <notice>
+        <name>android support library</name>
+        <url>https://android.googlesource.com/</url>
+        <copyright>Copyright (C) 2011 The Android Open Source Project</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>RoboGuice 2.0</name>
-        <url>http://roboguice.org</url>
-        <copyright/>
+        <name>gson</name>
+        <url>https://github.com/google/gson</url>
+        <copyright>Copyright 2008 Google Inc.</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>Application Crash Reporting for Android (ACRA)</name>
-        <url>http://acra.ch/</url>
-        <copyright>Copyright 2010 Emmanuel Astier &amp; Kevin Gaudin</copyright>
+        <name>glide</name>
+        <url>https://github.com/bumptech/glide</url>
+        <copyright>Copyright 2014 Google, Inc. All rights reserved.</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>Android ViewPagerIndicator</name>
-        <url>http://viewpagerindicator.com/</url>
-        <copyright>Copyright (C) 2011 The Android Open Source Project&lt;br/&gt;Copyright (C) 2012 Jake Wharton</copyright>
+        <name>android-volley</name>
+        <url>https://github.com/mcxiaoke/android-volley</url>
+        <copyright>Copyright (C) 2011 The Android Open Source Project (C) 2014 Xiaoke Zhang</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>Nine Old Androids</name>
-        <url>http://nineoldandroids.com/</url>
-        <copyright>Copyright (C) 2010 The Android Open Source Project</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>Crouton</name>
-        <url>https://github.com/keyboardsurfer/Crouton</url>
-        <copyright>Copyright 2012 Benjamin Weiss&lt;br/&gt;Copyright 2012 Neofonie Mobile GmbH</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>Jackson JSON-processor</name>
-        <url>http://jackson.codehaus.org/</url>
-        <copyright/>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>OrmLite</name>
-        <url>http://ormlite.com/</url>
-        <copyright>Copyright Gray Watson</copyright>
+        <name>volley-extensions</name>
+        <url>https://github.com/naver/volley-extensions</url>
+        <copyright>Copyright (C) 2014 Naver Corp.</copyright>
         <license>ISC License</license>
     </notice>
     <notice>
-        <name>Apache Commons IO</name>
-        <url>http://commons.apache.org/io/</url>
-        <copyright>Copyright 2002-2012 The Apache Software Foundation</copyright>
+        <name>facebook</name>
+        <url>https://github.com/facebook/facebook-android-sdk</url>
+        <copyright>Copyright 2002-2012 The Apache Software Foundation
+
+You are hereby granted a non-exclusive, worldwide, royalty-free license to use,copy, modify, and distribute this software in source code or binary form for usein connection with the web services and APIs provided by Facebook.
+
+As with any software that integrates with the Facebook platform, your use of this software is subject to the Facebook Developer Principles and Policies [http://developers.facebook.com/policy/]. This copyright notice shall be included in all copies or substantial portions of the software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</copyright>
+    </notice>
+    <notice>
+        <name>MaterialViewPager</name>
+        <url>https://github.com/florent37/MaterialViewPager</url>
+        <copyright>Copyright 2015 florent37, Inc.</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>Apache Commons Lang</name>
-        <url>http://commons.apache.org/lang/</url>
-        <copyright>Copyright 2002-2011 The Apache Software Foundation</copyright>
+        <name>circlebutton</name>
+        <url>https://github.com/markushi/android-circlebutton/blob/master/LICENSE</url>
         <license>Apache Software License 2.0</license>
     </notice>
-    <notice>
-        <name>Joda Time</name>
-        <url>http://joda-time.sourceforge.net/</url>
-        <copyright>Copyright 2001-2005 Stephen Colebourne</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>StickyListHeaders</name>
-        <url>https://github.com/emilsjolander/StickyListHeaders</url>
-        <copyright>Copyright 2012 Emil Sjölander</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>DiskLruCache</name>
-        <url>https://github.com/JakeWharton/DiskLruCache</url>
-        <copyright>Copyright (C) 2011 The Android Open Source Project&lt;br/&gt;Copyright 2012 Jake Wharton</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>Google Guava</name>
-        <url>http://code.google.com/p/guava-libraries/</url>
-        <copyright>Copyright (C) 2007 The Guava Authors</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>PhotoView</name>
-        <url>https://github.com/chrisbanes/PhotoView</url>
-        <copyright>Copyright 2011, 2012 Chris Banes.</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>Inscription</name>
-        <url>https://github.com/MartinvanZ/Inscription</url>
-        <copyright>(c) 2012 Martin van Zuilekom (http://martin.cubeactive.com)</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>Cool Project with BSD License</name>
-        <url>http://example.com</url>
-        <copyright>Author of Cool Project with BSD License</copyright>
-        <license>BSD 3-Clause License</license>
-    </notice>
+
 </notices>


### PR DESCRIPTION
View : Make license view on setting folder in PreferenceFragment.
- 라이센스 다이얼로그 라이브러리 gradle에 추가.
- setting에서 라이센스 보는 화면에 라이센스 다이얼로그를 띄움
- res에 라이센스정보를 담을 raw 폴더 생성 후 라이브러리 형식에 맞는 라이센스 리스트를 추가함
