### PR TITLE
UI: SchedFrag: Fix an issue of All and Favorite sessions visibility

### DIFF
--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/sche/ScheFragment.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/sche/ScheFragment.java
@@ -215,16 +215,24 @@ public class ScheFragment extends BaseFragment {
     public void onResume() {
         super.onResume();
 
-        FavoritePreferenceHelper prefHelper = new FavoritePreferenceHelper(getActivity());
-        boolean favorSessionState = prefHelper.getFavorSessionState(FavoritePreferenceHelper.PREF_FAVOR_STATE);
+        if (mTitle.equals(getResources().getText(R.string.all_schedule))) {
 
-        if (favorSessionState) {
-            mEmptyLayout.setVisibility(View.GONE);
-            mToolbarSpinner.setVisibility(View.VISIBLE);
-        } else {
-            mEmptyLayout.setVisibility(View.VISIBLE);
-            mToolbarSpinner.setVisibility(View.GONE);
+            // all sessions
+            setEmptyViewVisible(false);
+
+        } else if (mTitle.equals(getResources().getText(R.string.my_schedule))) {
+
+            // favorite sessions
+            FavoritePreferenceHelper prefHelper = new FavoritePreferenceHelper(getActivity());
+            boolean favorSessionState = prefHelper.getFavorSessionState(FavoritePreferenceHelper.PREF_FAVOR_STATE);
+
+            setEmptyViewVisible(!favorSessionState);
         }
+    }
+
+    private void setEmptyViewVisible(boolean visible) {
+        mEmptyLayout.setVisibility(visible ? View.VISIBLE : View.GONE);
+        mToolbarSpinner.setVisibility(visible ? View.GONE : View.VISIBLE);
     }
 
     @Override


### PR DESCRIPTION
ScheFragment::onResume() 메소드에서 mTitle에 따라 mEmptyLayout과 mToolbarSpinner가 다르게 보여지는 것을 수정했습니다.
이 부분을 atomic하게 처리하기 위해 setEmptyViewVisible()로 따로 메서드를 만들었습니다.
