### PR TITLE
View & Readme: Make license view on setting folder in PreferenceFragment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Deviewsched는 대한민국 최대의 개발자 컨퍼런스 Deview를 타겟으
 - 설정
 
 ## 라이선스
-본 프로젝트는 MIT 라이선스를 따르고 있습니다.
+- Junit(http://junit.org/license.html)
+- Robolectric(https://github.com/robolectric/robolectric)
+- Android support library(https://android.googlesource.com/platform/frameworks/support/+/master/v13/java/android/support/v13/app/FragmentCompat.java)
+- Gson(https://github.com/google/gson)
+- Guava - Apache
+- Glide(https://github.com/bumptech/glide)
+- Volley(https://github.com/mcxiaoke/android-volley)
+- Volleyextensions(https://github.com/naver/volley-extensions)
+- Facebook-android-sdk(https://github.com/facebook/facebook-android-sdk)
+- Materialviewpager(https://github.com/florent37/MaterialViewPager)
+- Circlebutton(https://github.com/markushi/android-circlebutton)
+
 
 ## 개발자

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile('de.psdev.licensesdialog:licensesdialog:1.8.0')
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:cardview-v7:23.1.1'

--- a/app/src/main/java/com/gdgssu/android_deviewsched/ui/setting/PreferenceFragment.java
+++ b/app/src/main/java/com/gdgssu/android_deviewsched/ui/setting/PreferenceFragment.java
@@ -6,9 +6,12 @@ import android.os.Bundle;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
+import android.view.View;
 
 import com.gdgssu.android_deviewsched.R;
 import com.gdgssu.android_deviewsched.util.LogUtils;
+
+import de.psdev.licensesdialog.LicensesDialogFragment;
 
 import static com.gdgssu.android_deviewsched.util.LogUtils.makeLogTag;
 
@@ -54,14 +57,26 @@ public class PreferenceFragment extends PreferenceFragmentCompat implements Shar
 
             case KEY_PREF_OSSLICENSES:
                 //Todo : SettingActivity에서 PreferenceFragment에서 OSSlicensesFragment로 전환하는 로직 작성
-                mListener.onFragmentChange();
-
+               // mListener.onFragmentChange();
+                try {
+                    onMultipleIncludeOwnFragmentClick(getView());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
                 break;
         }
 
         return super.onPreferenceTreeClick(preference);
     }
+    public void onMultipleIncludeOwnFragmentClick(final View view) throws Exception {
+        final LicensesDialogFragment fragment = new LicensesDialogFragment.Builder(getActivity())
+                .setNotices(R.raw.notices)
+                .setShowFullLicenseText(false)
+                .setIncludeOwnLicense(true)
+                .build();
 
+        fragment.show(getFragmentManager(), null);
+    }
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2013 Philip Schiffer
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+<notices>
+    <notice>
+        <name>robolectric</name>
+        <url>http://robolectric.org/</url>
+        <copyright>Copyright (c) 2010 Xtreme Labs and Pivotal Labs</copyright>
+        <license>MIT License</license>
+    </notice>
+    <notice>
+        <name>android support library</name>
+        <url>https://android.googlesource.com/</url>
+        <copyright>Copyright (C) 2011 The Android Open Source Project</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>gson</name>
+        <url>https://github.com/google/gson</url>
+        <copyright>Copyright 2008 Google Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>glide</name>
+        <url>https://github.com/bumptech/glide</url>
+        <copyright>Copyright 2014 Google, Inc. All rights reserved.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>android-volley</name>
+        <url>https://github.com/mcxiaoke/android-volley</url>
+        <copyright>Copyright (C) 2011 The Android Open Source Project (C) 2014 Xiaoke Zhang</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>volley-extensions</name>
+        <url>https://github.com/naver/volley-extensions</url>
+        <copyright>Copyright (C) 2014 Naver Corp.</copyright>
+        <license>ISC License</license>
+    </notice>
+    <notice>
+        <name>facebook</name>
+        <url>https://github.com/facebook/facebook-android-sdk</url>
+        <copyright>Copyright 2002-2012 The Apache Software Foundation
+
+You are hereby granted a non-exclusive, worldwide, royalty-free license to use,copy, modify, and distribute this software in source code or binary form for usein connection with the web services and APIs provided by Facebook.
+
+As with any software that integrates with the Facebook platform, your use of this software is subject to the Facebook Developer Principles and Policies [http://developers.facebook.com/policy/]. This copyright notice shall be included in all copies or substantial portions of the software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</copyright>
+    </notice>
+    <notice>
+        <name>MaterialViewPager</name>
+        <url>https://github.com/florent37/MaterialViewPager</url>
+        <copyright>Copyright 2015 florent37, Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>circlebutton</name>
+        <url>https://github.com/markushi/android-circlebutton/blob/master/LICENSE</url>
+        <license>Apache Software License 2.0</license>
+    </notice>
+
+</notices>


### PR DESCRIPTION
- 라이센스 다이얼로그 라이브러리 gradle에 추가.
- setting에서 라이센스 보는 화면에 라이센스 다이얼로그를 띄움
- res에 라이센스정보를 담을 raw 폴더 생성

license : make license list
- res/raw에 있는 notices.xml에 오픈소스 라이센스 리스트를 라이브러리 형식에 맞춰 추가함.

README : Add license list in README.md

-라이센스명+URL으로 라이센스 리스트를 첨부했습니다.
